### PR TITLE
Danaj/unsafe decoding

### DIFF
--- a/lib/Convert/ASN1/_decode.pm
+++ b/lib/Convert/ASN1/_decode.pm
@@ -685,6 +685,7 @@ sub _scan_indef {
     if((ord($tag) & 0x1f) == 0x1f) {
       my $b;
       do {
+	return if $pos >= $end;
 	$tag .= substr($_[0],$pos++,1);
 	$b = ord substr($tag,-1);
       } while($b & 0x80);

--- a/lib/Convert/ASN1/_decode.pm
+++ b/lib/Convert/ASN1/_decode.pm
@@ -679,6 +679,7 @@ sub _scan_indef {
       $pos += 2;
       next;
     }
+    return if $pos >= $end;
 
     my $tag = substr($_[0], $pos++, 1);
 


### PR DESCRIPTION
Fix for issue 14: "Unsafe decoding creates infinite loop".

Version 0.26 on CPAN is missing both position checks.  The commit a year ago for issue 8 added one of them.  This adds the other.

I did not add anything to the tests.  Issue 14 has a simple test shown.

These changes should help with RT 27574 for Convert::PEM.
