### PR TITLE
Decode PDUs with varbinds pointing to noSuchInstance OIDs

### DIFF
--- a/lib/Convert/ASN1/_decode.pm
+++ b/lib/Convert/ASN1/_decode.pm
@@ -243,7 +243,11 @@ sub _decode {
 	      next OP;
 	    }
 	  }
-	  die "decode error" unless $op->[cEXT];
+	  if (!$op->[cEXT]) {
+		print STDERR "Convert::ASN1::_decode cEXT was not defined: noSuchInstance\n";
+		$stash->{$op->[cVAR]} = {'noSuchInstance' => 'noSuchInstance'};
+		$pos = $end; # Skip over the rest
+	  }
 	}
 	elsif ($op->[cTYPE] == opEXTENSIONS) {
 	    $pos = $end; # Skip over the rest


### PR DESCRIPTION
PDUs that tcpdump interprets as:

```
V2Trap(224)
  .1.3.6.1.2.1.1.3.0=3158708931
  .1.3.6.1.6.3.1.1.4.1.0=.1.3.6.1.4.1.9.0.1 .1.3.6.1.4.1.9.2.9.3.1.1.2.1=6
  .1.3.6.1.2.1.6.13.1.1.32.1.7.184.22.32.1.7.184.43666=5
  .1.3.6.1.4.1.9.2.6.1.1.5.32.1.7.184.22.32.1.7.184.43666=[noSuchInstance]
  .1.3.6.1.4.1.9.2.6.1.1.1.32.1.7.184.22.32.1.7.184.43666=[noSuchInstance]
  .1.3.6.1.4.1.9.2.6.1.1.2.32.1.7.184.22.32.1.7.184.43666=[noSuchInstance]
  .1.3.6.1.4.1.9.2.9.2.1.18.2="rancid"
```

Result in a very obscure 'decode error' in _decode.pm because of the [noSuchInstance] varbinds. This pull request was hacked together but seems to work to pass them on anyways and decode the PDU (SNMP Trap in my case).
