### PR TITLE
Fix test failures under Perl 5.26+ without '.' in @INC

### DIFF
--- a/t/00prim.t
+++ b/t/00prim.t
@@ -8,7 +8,7 @@ use Convert::ASN1 qw(:all);
 
 print "1..186\n";
 
-BEGIN { require 't/funcs.pl' }
+BEGIN { require './t/funcs.pl' }
 
 ntest 1, 129,      asn_tag(ASN_CONTEXT, 1);
 ntest 2, 0x201f,   asn_tag(ASN_UNIVERSAL, 32);

--- a/t/01tag.t
+++ b/t/01tag.t
@@ -5,7 +5,7 @@
 #
 
 use Convert::ASN1;
-BEGIN { require 't/funcs.pl' }
+BEGIN { require './t/funcs.pl' }
 
 print "1..21\n";
 

--- a/t/02seq.t
+++ b/t/02seq.t
@@ -5,7 +5,7 @@
 #
 
 use Convert::ASN1;
-BEGIN { require 't/funcs.pl' }
+BEGIN { require './t/funcs.pl' }
 
 print "1..18\n";
 

--- a/t/03seqof.t
+++ b/t/03seqof.t
@@ -4,7 +4,7 @@
 # Test that the primitive operators are working
 #
 
-BEGIN { require 't/funcs.pl' }
+BEGIN { require './t/funcs.pl' }
 
 use Convert::ASN1;
 

--- a/t/04opt.t
+++ b/t/04opt.t
@@ -5,7 +5,7 @@
 #
 
 use Convert::ASN1;
-BEGIN { require 't/funcs.pl' }
+BEGIN { require './t/funcs.pl' }
 
 print "1..16\n"; # This testcase needs more tests
 

--- a/t/05time.t
+++ b/t/05time.t
@@ -10,7 +10,7 @@ use Convert::ASN1 qw(:all);
 
 print "1..24\n";
 
-BEGIN { require 't/funcs.pl' }
+BEGIN { require './t/funcs.pl' }
 
 my $t = 1;
 

--- a/t/06bigint.t
+++ b/t/06bigint.t
@@ -5,7 +5,7 @@
 #
 
 use Convert::ASN1;
-BEGIN { require 't/funcs.pl' }
+BEGIN { require './t/funcs.pl' }
 
 $^W=0 if $] < 5.005; # BigInt in 5.004 has undef issues
 

--- a/t/08set.t
+++ b/t/08set.t
@@ -5,7 +5,7 @@
 #
 
 use Convert::ASN1;
-BEGIN { require 't/funcs.pl' }
+BEGIN { require './t/funcs.pl' }
 
 print "1..13\n";
 

--- a/t/09contr.t
+++ b/t/09contr.t
@@ -5,7 +5,7 @@
 #
 
 use Convert::ASN1;
-BEGIN { require 't/funcs.pl' }
+BEGIN { require './t/funcs.pl' }
 
 print "1..4\n";
 

--- a/t/10choice.t
+++ b/t/10choice.t
@@ -5,7 +5,7 @@
 #
 
 use Convert::ASN1;
-BEGIN { require 't/funcs.pl' }
+BEGIN { require './t/funcs.pl' }
 
 print "1..10\n";
 

--- a/t/11explicit.t
+++ b/t/11explicit.t
@@ -1,6 +1,6 @@
 #!/usr/local/bin/perl
 
-BEGIN { require 't/funcs.pl' }
+BEGIN { require './t/funcs.pl' }
 
 use Convert::ASN1;
 

--- a/t/11indef.t
+++ b/t/11indef.t
@@ -4,7 +4,7 @@
 # Test that indefinite length encodings can be decoded
 #
 
-BEGIN { require 't/funcs.pl' }
+BEGIN { require './t/funcs.pl' }
 
 use Convert::ASN1;
 my @zz = ( 0, 0 );

--- a/t/12der.t
+++ b/t/12der.t
@@ -5,7 +5,7 @@
 #
 
 use Convert::ASN1;
-BEGIN { require 't/funcs.pl' }
+BEGIN { require './t/funcs.pl' }
 
 print "1..18\n";
 

--- a/t/13utf8.t
+++ b/t/13utf8.t
@@ -5,7 +5,7 @@
 #
 
 use Convert::ASN1;
-BEGIN { require 't/funcs.pl' }
+BEGIN { require './t/funcs.pl' }
 
 if ($] < 5.007) {
   print "1..0\n";

--- a/t/14any.t
+++ b/t/14any.t
@@ -4,7 +4,7 @@
 # Check whether the ANY DEFINED BY syntax is working
 #
 
-BEGIN { require 't/funcs.pl'}
+BEGIN { require './t/funcs.pl'}
 
 use Convert::ASN1;
 

--- a/t/15extseq.t
+++ b/t/15extseq.t
@@ -5,7 +5,7 @@
 #
 
 use Convert::ASN1;
-BEGIN { require 't/funcs.pl' }
+BEGIN { require './t/funcs.pl' }
 
 print "1..27\n";
 

--- a/t/16extset.t
+++ b/t/16extset.t
@@ -5,7 +5,7 @@
 #
 
 use Convert::ASN1;
-BEGIN { require 't/funcs.pl' }
+BEGIN { require './t/funcs.pl' }
 
 print "1..27\n";
 

--- a/t/17extchoice.t
+++ b/t/17extchoice.t
@@ -5,7 +5,7 @@
 #
 
 use Convert::ASN1;
-BEGIN { require 't/funcs.pl' }
+BEGIN { require './t/funcs.pl' }
 
 print "1..19\n";
 

--- a/t/18tagdefault.t
+++ b/t/18tagdefault.t
@@ -5,7 +5,7 @@
 #
 
 use Convert::ASN1;
-BEGIN { require 't/funcs.pl' }
+BEGIN { require './t/funcs.pl' }
 
 print "1..25\n";
 

--- a/t/99misc.t
+++ b/t/99misc.t
@@ -5,7 +5,7 @@
 #
 
 use Convert::ASN1;
-BEGIN { require 't/funcs.pl' }
+BEGIN { require './t/funcs.pl' }
 
 print "1..2\n";
 

--- a/t/x509.t
+++ b/t/x509.t
@@ -2,7 +2,7 @@
 
 print "1..26\n";
 
-BEGIN { require 't/funcs.pl' }
+BEGIN { require './t/funcs.pl' }
 
 use Convert::ASN1;
 


### PR DESCRIPTION
Bug: https://github.com/gbarr/perl-Convert-ASN1/issues/33
Bug: https://bugs.gentoo.org/613638